### PR TITLE
Annotatedaudio/enable adding annotation without prior label creation

### DIFF
--- a/annotatedaudio/frontend/player/AudioPlayerWithAnnotation.svelte
+++ b/annotatedaudio/frontend/player/AudioPlayerWithAnnotation.svelte
@@ -656,8 +656,8 @@
 			</div>
 			{#if value}
 				<Caption
-					value={value.annotations}
 					bind:this={caption}
+					bind:annotations={value.annotations}
 					on:select={(e) => setRegionSpeaker(e.detail)}
 					on:select={(e) => activeLabel = e.detail}
 				/>

--- a/annotatedaudio/frontend/player/AudioPlayerWithAnnotation.svelte
+++ b/annotatedaudio/frontend/player/AudioPlayerWithAnnotation.svelte
@@ -155,11 +155,10 @@
 	 * @param relativeY mouse y-coordinate relative to waveform start
 	 */
 	function handleRegionAdd(relativeY: number): void{
-		let label = (activeLabel !== null ? activeLabel : defaultLabel);
+		let label = (activeLabel ? activeLabel : defaultLabel);
 		// if annotations were not initialized, do nothing
-		if (label === null){
-			window.alert("First create a label by clicking on \"+\" or by pressing A-Z");
-			return;
+		if (!label){
+			label = caption.createLabel();
 		}
 		let region = addRegion({
 			start: relativeY - 1.0,

--- a/annotatedaudio/frontend/shared/Caption.svelte
+++ b/annotatedaudio/frontend/shared/Caption.svelte
@@ -3,7 +3,7 @@
     import Plus from "./icons/Plus.svelte";
     import { createEventDispatcher, onMount} from "svelte";
 
-    export let value: Annotation[] | null = null;
+    export let annotations: Annotation[] | null = null;
 
     let container: HTMLDivElement;
 
@@ -36,7 +36,7 @@
             return;
         }
         if(!speaker){
-            speaker = "SPEAKER_" + speakerIdx.toString().padStart(2, "0");
+            speaker = "LABEL_" + speakerIdx.toString().padStart(2, "0");
         }
         if(!color){
             color = colorList[speakerIdx % colorList.length];
@@ -89,9 +89,9 @@
     }
 
     $:{
-        if(container && value){
+        if(container && annotations){
             // retrieve speaker list and corresponding annotation color
-            value.forEach(annotation => {
+            annotations.forEach(annotation => {
                 // if annotation has a label that does not already exist in the caption,
                 // create a new label
                 if(!labels.some(label => label.speaker === annotation.speaker)){

--- a/annotatedaudio/pyproject.toml
+++ b/annotatedaudio/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gryannote_audio"
-version = "0.1.5"
+version = "0.1.6"
 description = "audio component with speaker annotations"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Up to now, a pop-up asking the user to firstly create a label was printed on the interface when it is trying  to add an annotation whereas there is no existing label. With this PR, a new label is automatically created.