### PR TITLE
implement region overlap management in the frontend

### DIFF
--- a/annotatedaudio/backend/gryannote_audio/core.py
+++ b/annotatedaudio/backend/gryannote_audio/core.py
@@ -1,6 +1,5 @@
 from typing import ClassVar, Dict, List, Optional, Text
 
-import networkx as nx
 from gradio.data_classes import FileData, GradioModel
 from pyannote.core import Annotation as PyannoteAnnotation
 
@@ -15,26 +14,18 @@ class Annotation(GradioModel):
     end: float
     # annotation speaker label
     speaker: Text
-    # css style level of the annotation
-    level: Optional[int]
-    # total num level
-    num_levels: Optional[int]
 
     def __init__(
         self,
         start: float,
         end: float,
         speaker: Text,
-        level: Optional[int] = None,
-        num_levels: Optional[int] = None,
         **kwargs,
     ):
         super().__init__(
             start=start,
             end=end,
             speaker=speaker,
-            level=level,
-            num_levels=num_levels,
         )
 
 
@@ -58,35 +49,16 @@ class AnnotadedAudioData(GradioModel):
             **kwargs,
         )
 
-    def _prepare_annotations(self, annotations) -> List[Annotation]:
+    def _prepare_annotations(self, annotations: List[PyannoteAnnotation]) -> List[Annotation]:
 
         prepared_annotations: List[Annotation] = []
 
-        # compute overlap graph (one node per annotation, edges between overlapping regions)
-        overlap_graph = nx.Graph()
-        for (s1, t1), (s2, t2) in annotations.co_iter(annotations):
-            overlap_graph.add_edge((s1, t1), (s2, t2))
-
-        # solve the graph coloring problem for each connected subgraph and
-        # use the solution for annotations layout
-        for sub_graph in nx.connected_components(overlap_graph):
-            sub_coloring = nx.coloring.greedy_color(
-                overlap_graph.subgraph(sorted(sub_graph))
-            )
-
-            num_colors = max(sub_coloring.values()) + 1
-            for (segment, annotation_id), color in sub_coloring.items():
-                # assumes that no more than 4 annotations can overlap at any given time
-                level = (color % 4 if num_colors > 4 else color) + 1
-                num_levels = 4 if num_colors > 4 else num_colors
-
-                prepared_annotations.append(
-                    Annotation(
-                        start=segment.start,
-                        end=segment.end,
-                        speaker=annotations[segment, annotation_id],
-                        level=level,
-                        num_levels=num_levels,
-                    )
+        for segment, _ , label in annotations.itertrack(yield_label=True) :
+            prepared_annotations.append(
+                Annotation(
+                    start=segment.start,
+                    end=segment.end,
+                    speaker=label,
                 )
+            )
         return prepared_annotations

--- a/annotatedaudio/backend/gryannote_audio/core.py
+++ b/annotatedaudio/backend/gryannote_audio/core.py
@@ -53,7 +53,7 @@ class AnnotadedAudioData(GradioModel):
 
         prepared_annotations: List[Annotation] = []
 
-        for segment, _ , label in annotations.itertrack(yield_label=True) :
+        for segment, _ , label in annotations.itertracks(yield_label=True) :
             prepared_annotations.append(
                 Annotation(
                     start=segment.start,

--- a/annotatedaudio/frontend/player/AudioPlayerWithAnnotation.svelte
+++ b/annotatedaudio/frontend/player/AudioPlayerWithAnnotation.svelte
@@ -87,8 +87,9 @@
 			}
 		});
 
-		// resolve graph coloring problem
-		let graphColoring = regionsGraph.greedyColoring();
+		// resolve graph coloring problem on graph connected component to which the region belongs
+		let regionConnectedComponent = regionsGraph.getConnectedComponent(region)
+		let graphColoring = regionConnectedComponent.greedyColoring();
 		let numColors = Math.max(...Array.from(graphColoring.values())) + 1;
 		// update regions alignement
 		wsRegions.getRegions().forEach(region => {

--- a/annotatedaudio/frontend/player/AudioPlayerWithAnnotation.svelte
+++ b/annotatedaudio/frontend/player/AudioPlayerWithAnnotation.svelte
@@ -104,8 +104,13 @@
 		regionsGraph.removeNode(region);
 	}
 
+	/**
+	 * Update region vertical alignement on the waveform
+	 * @param region region to be updated
+	 * @param regionColor color of the region in the overlapping graph
+	 * @param numColors total number of colors in the overlapping graph
+	 */
 	function updateRegionAlignement(region: Region, regionColor: number, numColors: number){
-		// update region alignement style:
 		let top = 0;
 		let height = 0;
 		if(numColors > 4){
@@ -115,6 +120,8 @@
 			top = (regionColor + 1) * 10;
 			height = (100 - (numColors + 1) * 10)
 		}
+
+		// update region alignement style:
 		region.element.style.top = top.toString() + "%";
 		region.element.style.height = height.toString() + "%";
 	}

--- a/annotatedaudio/frontend/player/AudioPlayerWithAnnotation.svelte
+++ b/annotatedaudio/frontend/player/AudioPlayerWithAnnotation.svelte
@@ -53,7 +53,7 @@
 	let activeLabel: CaptionLabel | null = null;
 
 	// nodes = regions (id), edges = overlap between linked regions
-	let regionsGraph: Graph = new Graph()
+	let regionsGraph: Graph<string> = new Graph()
 
 	const dispatch = createEventDispatcher<{
 		stop: undefined;

--- a/annotatedaudio/frontend/shared/graph.ts
+++ b/annotatedaudio/frontend/shared/graph.ts
@@ -6,22 +6,47 @@ export default class Graph {
         this.edges = new Map<string, string[]>();
     }
 
+    /**
+     * Get the number of node in this graph
+     * @returns number of node in this graph
+     */
     public getNumNodes(): number {
         return this.numNodes;
     }
-
+    
+    /**
+     * Get the list of nodes in this graph
+     * @returns list of nodes
+     */
     public getNodesList(): string[] {
         return Array.from(this.edges.keys());
     }
 
+    /**
+     * Get nodes adjacent to the specified one
+     * @param node
+     * @returns adjacent nodes in this graph
+     */
     public getAdjNodes(node: string): string[] | undefined{
         return this.edges.get(node);
     }
 
+    /**
+     *  Check whether the specified node is in this graph
+     * @param node node to be be checked
+     * @returns true if the specified node is in this graph, false otherwise
+     */
     public isNodeInGraph(node: string) {
         return this.edges.get(node) !== undefined;
     }
 
+    /**
+     * Check whether the edge (node1, node2) is in this graph. Calling this method for
+     * the edge (node2, node1) will return the same result, as the graph is non-oriented.
+     * @param node1 edge's first node
+     * @param node2 edge's second node
+     * @returns true if the edge is in this graph, false otherwise
+     */
     public isEdgeInGraph(node1: string, node2: string){
         let adjNodes = this.getAdjNodes(node1);
         if(adjNodes === undefined){
@@ -33,6 +58,10 @@ export default class Graph {
         return true;
     }
 
+    /**
+     * Add specified node to this graph
+     * @param node node to be added
+     */
     public addNode(node: string): void{
         if(!this.isNodeInGraph(node)){
             this.edges.set(node, []);
@@ -40,6 +69,12 @@ export default class Graph {
         }
     }
 
+    /**
+     * Add an edge between the two specified node
+     * Note: (node1, node2) === (node2, node1)
+     * @param node1 edge's first node
+     * @param node2 edge's second node
+     */
     public addEdge(node1:string, node2: string): void{
         // do not create an edge if nodes are the same
         if(node1 === node2){
@@ -62,6 +97,11 @@ export default class Graph {
         this.getAdjNodes(node2)?.push(node1);
     }
 
+    /**
+     * Remove the specified node from this graph
+     * @param node node to be removed
+     * @returns true if the node has been successfully removed, false otherwise
+     */
     public removeNode(node: string): boolean {
         let adjNodes = this.getAdjNodes(node);
         if(adjNodes !== undefined){
@@ -78,6 +118,12 @@ export default class Graph {
         return false;
     }
 
+    /**
+     * Remove the edge (node1, node2) from this graph. Calling this method for edge
+     * (node2, node1) will give the same result.
+     * @param node1 edge's first node
+     * @param node2 edge's second node
+     */
     public removeEdge(node1:string, node2: string): void{
         if(!this.isEdgeInGraph(node1, node2)){
             // if one of the specified node not in graph, do nothing
@@ -87,6 +133,10 @@ export default class Graph {
         this.getAdjNodes(node2)?.splice(Number(this.getAdjNodes(node1)?.indexOf(node1)), 1);
     }
 
+    /**
+     * 
+     * @returns 
+     */
     public greedyColoring(){
         // map associating a color at each graph node:
         let nodesColor = new Map<string, number>()
@@ -112,6 +162,20 @@ export default class Graph {
         return nodesColor;
     }
 
+    /**
+     * Get the connected component of the graph to which the specified node belongs.
+     * @param node 
+     * @returns A graph representing the connected component of the specified node.
+     */
+    public getConnectedComponent(node: string): Graph {
+        let visitedNodes: string[] = [];
+        let connectedComponent: Graph = new Graph();
+
+        this.getConnectedComponentHelper(node, visitedNodes, connectedComponent);
+        
+        return connectedComponent;
+    }
+
     private getConnectedComponentHelper(node: string, visitedNodes: string[], connectedComponent: Graph): void{
         visitedNodes.push(node);
         connectedComponent.addNode(node);
@@ -121,15 +185,6 @@ export default class Graph {
                 this.getConnectedComponentHelper(adjNode, visitedNodes, connectedComponent);
             }
         });
-    }
-
-    public getConnectedComponent(node: string): Graph {
-        let visitedNodes: string[] = [];
-        let connectedComponent: Graph = new Graph();
-
-        this.getConnectedComponentHelper(node, visitedNodes, connectedComponent);
-        
-        return connectedComponent;
     }
 
 }

--- a/annotatedaudio/frontend/shared/graph.ts
+++ b/annotatedaudio/frontend/shared/graph.ts
@@ -1,5 +1,5 @@
 export default class Graph {
-    edges: Map<string, string[]>
+    edges: Map<string, string[]>;
     numNodes: number = 0;
 
     constructor(){
@@ -11,10 +11,10 @@ export default class Graph {
     }
 
     public getNodesList(): string[] {
-        return Array.from(this.edges.keys())
+        return Array.from(this.edges.keys());
     }
 
-    public getAdj(node: string): string[] | undefined{
+    public getAdjNodes(node: string): string[] | undefined{
         return this.edges.get(node);
     }
 
@@ -23,7 +23,7 @@ export default class Graph {
     }
 
     public isEdgeInGraph(node1: string, node2: string){
-        let adjNodes = this.edges.get(node1);
+        let adjNodes = this.getAdjNodes(node1);
         if(adjNodes === undefined){
             return false;
         }
@@ -58,12 +58,12 @@ export default class Graph {
             this.addNode(node2);
         }
         // non-oriented graph
-        this.edges.get(node1)?.push(node2);
-        this.edges.get(node2)?.push(node1);
+        this.getAdjNodes(node1)?.push(node2);
+        this.getAdjNodes(node2)?.push(node1);
     }
 
     public removeNode(node: string): boolean {
-        let adjNodes = this.edges.get(node);
+        let adjNodes = this.getAdjNodes(node);
         if(adjNodes !== undefined){
             // remove all the corresponding edges
             adjNodes.forEach(adjNode => {
@@ -83,8 +83,8 @@ export default class Graph {
             // if one of the specified node not in graph, do nothing
             return;
         }
-        this.edges.get(node1)?.splice(Number(this.edges.get(node1)?.indexOf(node2)), 1)
-        this.edges.get(node2)?.splice(Number(this.edges.get(node1)?.indexOf(node1)), 1)
+        this.getAdjNodes(node1)?.splice(Number(this.getAdjNodes(node1)?.indexOf(node2)), 1);
+        this.getAdjNodes(node2)?.splice(Number(this.getAdjNodes(node1)?.indexOf(node1)), 1);
     }
 
     public greedyColoring(){
@@ -93,7 +93,7 @@ export default class Graph {
         let isColorAvailable = new Array(this.numNodes).fill(true);
         
         this.getNodesList().forEach(node => {
-            this.getAdj(node)?.forEach(adjNode =>{
+            this.getAdjNodes(node)?.forEach(adjNode =>{
                 // get color of adjacent nodes and remove them from available color
                 let nodeColor = nodesColor.get(adjNode);
                 if(nodeColor !== undefined){
@@ -106,10 +106,30 @@ export default class Graph {
             }
             nodesColor.set(node, color);
             // reset available color for the next iteration
-            isColorAvailable.fill(true)
+            isColorAvailable.fill(true);
         });
 
         return nodesColor;
+    }
+
+    private getConnectedComponentHelper(node: string, visitedNodes: string[], connectedComponent: Graph): void{
+        visitedNodes.push(node);
+        connectedComponent.addNode(node);
+        this.getAdjNodes(node)?.forEach(adjNode => {
+            connectedComponent.addEdge(node, adjNode);
+            if(visitedNodes.find(visitedNode => visitedNode === adjNode) === undefined){
+                this.getConnectedComponentHelper(adjNode, visitedNodes, connectedComponent);
+            }
+        });
+    }
+
+    public getConnectedComponent(node: string): Graph {
+        let visitedNodes: string[] = [];
+        let connectedComponent: Graph = new Graph();
+
+        this.getConnectedComponentHelper(node, visitedNodes, connectedComponent);
+        
+        return connectedComponent;
     }
 
 }

--- a/annotatedaudio/frontend/shared/graph.ts
+++ b/annotatedaudio/frontend/shared/graph.ts
@@ -1,9 +1,9 @@
-export default class Graph {
-    edges: Map<string, string[]>;
+export default class Graph<N> {
+    edges: Map<N, N[]>;
     numNodes: number = 0;
 
     constructor(){
-        this.edges = new Map<string, string[]>();
+        this.edges = new Map<N, N[]>();
     }
 
     /**
@@ -18,7 +18,7 @@ export default class Graph {
      * Get the list of nodes in this graph
      * @returns list of nodes
      */
-    public getNodesList(): string[] {
+    public getNodesList(): N[] {
         return Array.from(this.edges.keys());
     }
 
@@ -27,7 +27,7 @@ export default class Graph {
      * @param node
      * @returns adjacent nodes in this graph
      */
-    public getAdjNodes(node: string): string[] | undefined{
+    public getAdjNodes(node: N): N[] | undefined{
         return this.edges.get(node);
     }
 
@@ -36,7 +36,7 @@ export default class Graph {
      * @param node node to be be checked
      * @returns true if the specified node is in this graph, false otherwise
      */
-    public isNodeInGraph(node: string) {
+    public isNodeInGraph(node: N) {
         return this.edges.get(node) !== undefined;
     }
 
@@ -47,7 +47,7 @@ export default class Graph {
      * @param node2 edge's second node
      * @returns true if the edge is in this graph, false otherwise
      */
-    public isEdgeInGraph(node1: string, node2: string){
+    public isEdgeInGraph(node1: N, node2: N){
         let adjNodes = this.getAdjNodes(node1);
         if(adjNodes === undefined){
             return false;
@@ -62,7 +62,7 @@ export default class Graph {
      * Add specified node to this graph
      * @param node node to be added
      */
-    public addNode(node: string): void{
+    public addNode(node: N): void{
         if(!this.isNodeInGraph(node)){
             this.edges.set(node, []);
             this.numNodes += 1;
@@ -75,7 +75,7 @@ export default class Graph {
      * @param node1 edge's first node
      * @param node2 edge's second node
      */
-    public addEdge(node1:string, node2: string): void{
+    public addEdge(node1: N, node2: N): void{
         // do not create an edge if nodes are the same
         if(node1 === node2){
             return;
@@ -102,7 +102,7 @@ export default class Graph {
      * @param node node to be removed
      * @returns true if the node has been successfully removed, false otherwise
      */
-    public removeNode(node: string): boolean {
+    public removeNode(node: N): boolean {
         let adjNodes = this.getAdjNodes(node);
         if(adjNodes !== undefined){
             // remove all the corresponding edges
@@ -124,7 +124,7 @@ export default class Graph {
      * @param node1 edge's first node
      * @param node2 edge's second node
      */
-    public removeEdge(node1:string, node2: string): void{
+    public removeEdge(node1: N, node2: N): void{
         if(!this.isEdgeInGraph(node1, node2)){
             // if one of the specified node not in graph, do nothing
             return;
@@ -139,7 +139,7 @@ export default class Graph {
      */
     public greedyColoring(){
         // map associating a color at each graph node:
-        let nodesColor = new Map<string, number>()
+        let nodesColor = new Map<N, number>()
         let isColorAvailable = new Array(this.numNodes).fill(true);
         
         this.getNodesList().forEach(node => {
@@ -167,16 +167,16 @@ export default class Graph {
      * @param node 
      * @returns A graph representing the connected component of the specified node.
      */
-    public getConnectedComponent(node: string): Graph {
-        let visitedNodes: string[] = [];
-        let connectedComponent: Graph = new Graph();
+    public getConnectedComponent(node: N): Graph<N> {
+        let visitedNodes: N[] = [];
+        let connectedComponent: Graph<N> = new Graph();
 
         this.getConnectedComponentHelper(node, visitedNodes, connectedComponent);
         
         return connectedComponent;
     }
 
-    private getConnectedComponentHelper(node: string, visitedNodes: string[], connectedComponent: Graph): void{
+    private getConnectedComponentHelper(node: N, visitedNodes: N[], connectedComponent: Graph<N>): void{
         visitedNodes.push(node);
         connectedComponent.addNode(node);
         this.getAdjNodes(node)?.forEach(adjNode => {

--- a/annotatedaudio/frontend/shared/graph.ts
+++ b/annotatedaudio/frontend/shared/graph.ts
@@ -1,0 +1,115 @@
+export default class Graph {
+    edges: Map<string, string[]>
+    numNodes: number = 0;
+
+    constructor(){
+        this.edges = new Map<string, string[]>();
+    }
+
+    public getNumNodes(): number {
+        return this.numNodes;
+    }
+
+    public getNodesList(): string[] {
+        return Array.from(this.edges.keys())
+    }
+
+    public getAdj(node: string): string[] | undefined{
+        return this.edges.get(node);
+    }
+
+    public isNodeInGraph(node: string) {
+        return this.edges.get(node) !== undefined;
+    }
+
+    public isEdgeInGraph(node1: string, node2: string){
+        let adjNodes = this.edges.get(node1);
+        if(adjNodes === undefined){
+            return false;
+        }
+        if(adjNodes.find(adjNode => adjNode == node2) === undefined){
+            return false;
+        }
+        return true;
+    }
+
+    public addNode(node: string): void{
+        if(!this.isNodeInGraph(node)){
+            this.edges.set(node, []);
+            this.numNodes += 1;
+        }
+    }
+
+    public addEdge(node1:string, node2: string): void{
+        // do not create an edge if nodes are the same
+        if(node1 === node2){
+            return;
+        }
+
+        // do not add a edge if it already exists
+        if(this.isEdgeInGraph(node1, node2)){
+            return;
+        }
+
+        if(!this.isNodeInGraph(node1)){
+            this.addNode(node1);
+        }
+        if(!this.isNodeInGraph(node2)){
+            this.addNode(node2);
+        }
+        // non-oriented graph
+        this.edges.get(node1)?.push(node2);
+        this.edges.get(node2)?.push(node1);
+    }
+
+    public removeNode(node: string): boolean {
+        let adjNodes = this.edges.get(node);
+        if(adjNodes !== undefined){
+            // remove all the corresponding edges
+            adjNodes.forEach(adjNode => {
+                this.removeEdge(node, adjNode);
+            })
+            // remove node from the grap
+            this.edges.delete(node);
+            this.numNodes -= 1;
+
+            return true;
+        }
+        return false;
+    }
+
+    public removeEdge(node1:string, node2: string): void{
+        if(!this.isEdgeInGraph(node1, node2)){
+            // if one of the specified node not in graph, do nothing
+            return;
+        }
+        this.edges.get(node1)?.splice(Number(this.edges.get(node1)?.indexOf(node2)), 1)
+        this.edges.get(node2)?.splice(Number(this.edges.get(node1)?.indexOf(node1)), 1)
+    }
+
+    public greedyColoring(){
+        // map associating a color at each graph node:
+        let nodesColor = new Map<string, number>()
+        let isColorAvailable = new Array(this.numNodes).fill(true);
+        
+        this.getNodesList().forEach(node => {
+            this.getAdj(node)?.forEach(adjNode =>{
+                // get color of adjacent nodes and remove them from available color
+                let nodeColor = nodesColor.get(adjNode);
+                if(nodeColor !== undefined){
+                    isColorAvailable[nodeColor] = false;
+                }
+            });
+            let color: number;
+            for(color = 0; color < isColorAvailable.length; color++){
+                if(isColorAvailable[color]) break; // available color found
+            }
+            nodesColor.set(node, color);
+            // reset available color for the next iteration
+            isColorAvailable.fill(true)
+        });
+
+        return nodesColor;
+    }
+
+}

--- a/annotatedaudio/frontend/shared/types.ts
+++ b/annotatedaudio/frontend/shared/types.ts
@@ -11,8 +11,6 @@ export type Annotation = {
 	start: number
 	end: number
 	speaker: string
-	level?: number | undefined
-	numLevels?: number | undefined
 }
 
 export type CaptionLabel = {


### PR DESCRIPTION
So far, the display of overlapping regions was managed at backend level, and only for annotations produced by the pipeline. This means that regions added by the user were not taken into account, and the vertical alignment of regions was not dynamically updated. This PR moves this management to the frontend, with alignment dynamically updated according to changes made to annotations.