### PR TITLE
devolve handling of overlapped regions to @gryannote/wavesurfer.js

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,7 @@ rttm.upload(
 - if audio is paused, time cursor will be set to the start of the active annotation only if this annotation is not visible on the screen.
 - replace arithmetic zoom (z = z + delta) by a geometric one (z = z * coef)
 - add new shortcuts to speed up zoom in / zoom out: `SHIFT+UP` / `SHIFT+DOWN`
+- Managing of region overlapped is now devolved to `@gryannote/wavesurfer.js`
 
 ### fixes
 

--- a/gryannote/audio/frontend/package-lock.json
+++ b/gryannote/audio/frontend/package-lock.json
@@ -22,7 +22,7 @@
         "extendable-media-recorder-wav-encoder": "^7.0.76",
         "resize-observer-polyfill": "^1.5.1",
         "svelte-range-slider-pips": "^2.0.1",
-        "wavesurfer.js": "npm:@gryannote/wavesurfer.js@7.8.5"
+        "wavesurfer.js": "npm:@gryannote/wavesurfer.js@7.8.6"
       },
       "devDependencies": {
         "@gradio/preview": "^0.9.0"
@@ -4543,9 +4543,9 @@
     },
     "node_modules/wavesurfer.js": {
       "name": "@gryannote/wavesurfer.js",
-      "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/@gryannote/wavesurfer.js/-/wavesurfer.js-7.8.5.tgz",
-      "integrity": "sha512-suBNYQqOHiryzq7ZR2X+ONNAA9ruX0GKowIbAVHo/encz6fqyKnb6QBmRI77vF9a2H+4RC7gZGLzTOArM86OEQ==",
+      "version": "7.8.6",
+      "resolved": "https://registry.npmjs.org/@gryannote/wavesurfer.js/-/wavesurfer.js-7.8.6.tgz",
+      "integrity": "sha512-tfTAYOI0MgNjRCcKQiATqJRrhunQsOCht9obYXSbHpXCWSyH00lJNec9z1taMxMmVG6QVwHry7mh211+3q5Lww==",
       "license": "BSD-3-Clause"
     },
     "node_modules/which": {

--- a/gryannote/audio/frontend/package.json
+++ b/gryannote/audio/frontend/package.json
@@ -20,7 +20,7 @@
     "extendable-media-recorder-wav-encoder": "^7.0.76",
     "resize-observer-polyfill": "^1.5.1",
     "svelte-range-slider-pips": "^2.0.1",
-    "wavesurfer.js": "npm:@gryannote/wavesurfer.js@7.8.5"
+    "wavesurfer.js": "npm:@gryannote/wavesurfer.js@7.8.6"
   },
   "main_changeset": true,
   "main": "index.ts",

--- a/gryannote/audio/pyproject.toml
+++ b/gryannote/audio/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gryannote_audio"
-version = "0.6.0"
+version = "0.6.1"
 description = "audio component with speaker annotations"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Handling of overlapped regions is now directly done in the region plugin of `@gryannote/wavesurfer.js` (version 7.8.6)