### PR TITLE
add time info on audio player

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## main
+
+### New features
+
+- add a timeline on the audio player. Timeline's style can be customised using the new `timeline_options` attribute of `AudioLabeling` component.
+See `TimelineOptions` documentation for more details about available options
+- add timestamp when hovering over waveform with mouse cursor. This feature can be custom using th nex `hover_options` attribute of `AudioLabeling` component.
+See `HoverOptions` documentation for more details about available options
+
 ## 0.3.0
 
 ### Breaking changes

--- a/gryannote/audio/backend/gryannote_audio/audio_labeling.py
+++ b/gryannote/audio/backend/gryannote_audio/audio_labeling.py
@@ -57,6 +57,7 @@ class TimelineOptions:
         timeInterval: Interval between ticks in seconds
     """
 
+    # camelCase style is used here to match timeline's options in frontend
     height: int | float = 20
     insertPosition: Literal[
         "afterbegin", "afterend", "beforebegin", "beforeend"
@@ -67,6 +68,28 @@ class TimelineOptions:
     secondaryLabelOpacity: int | float = 0.25
     secondaryLabelSpacing: int | float = 1
     timeInterval: int | float = 1
+
+
+@dataclasses.dataclass
+class HoverOptions:
+    """
+    A dataclass for specifyinf options for the hover cursor display
+    in the `AudioLabeling` component.
+
+    Parameters:
+        labelBaground: color of the hover label background, default to grey
+        labelColor: color of the hover label text, default to white
+        labelSize: size of the hover label text in pixel, default to 11
+        lineColor: color of the hover line, default to red
+        lineWidth: width of the hover line in pixel, default to 2
+    """
+
+    # camelCase style is used here to match hover's options in frontend
+    labelBackground: str = "#555"
+    labelColor: str = "#fff"
+    labelSize: str | int | float = 11
+    lineColor: str = "#ff0000"
+    lineWidth: str | int | float = 2
 
 
 @document()
@@ -134,6 +157,7 @@ class AudioLabeling(
         max_length: int | None = None,
         waveform_options: WaveformOptions | dict | None = None,
         timeline_options: TimelineOptions | dict | None = None,
+        hover_options: HoverOptions | dict | None = None,
     ):
         """
         Parameters:
@@ -166,7 +190,12 @@ class AudioLabeling(
                 A dictionary of options for the timeline display.
                 Options include: height, insertPosition, primaryLabelInterval, primaryLabelSpacing,
                 secondaryLabelInterval, secondaryLabelOpacity, secondaryLabelSpacing, timeInterval.
-                See timeline wavesurfer plugin documentation for details about each of these options.
+                See `TimelineOptions` for more detail about these options
+            hover_options:
+                A dictionary of options for the hover cursor display
+                Options include: labelBackground, labelColor, labelSize, lineColor
+                and lineWidth.
+                See `HoverOptions` for more detail about these options
         """
         valid_sources = ["upload", "microphone"]
         if sources is None:
@@ -211,19 +240,30 @@ class AudioLabeling(
 
         if waveform_options is None:
             self.waveform_options = WaveformOptions()
-        self.waveform_options = (
-            WaveformOptions(**waveform_options)
-            if isinstance(waveform_options, dict)
-            else waveform_options
-        )
+        else:
+            self.waveform_options = (
+                WaveformOptions(**waveform_options)
+                if isinstance(waveform_options, dict)
+                else waveform_options
+            )
 
         if timeline_options is None:
             self.timeline_options = TimelineOptions()
-        self.timeline_options = (
-            TimelineOptions(**timeline_options)
-            if isinstance(timeline_options, dict)
-            else timeline_options
-        )
+        else:
+            self.timeline_options = (
+                TimelineOptions(**timeline_options)
+                if isinstance(timeline_options, dict)
+                else timeline_options
+            )
+
+        if hover_options is None:
+            self.hover_options = HoverOptions()
+        else:
+            self.hover_options = (
+                HoverOptions(**hover_options)
+                if isinstance(hover_options, dict)
+                else hover_options
+            )
 
         # TODO: What if annotations don't match audio?
         if audio:

--- a/gryannote/audio/backend/gryannote_audio/audio_labeling.py
+++ b/gryannote/audio/backend/gryannote_audio/audio_labeling.py
@@ -42,6 +42,33 @@ class WaveformOptions:
     sample_rate: int = 44100
 
 
+@dataclasses.dataclass
+class TimelineOptions:
+    """
+    A dataclass for specifying options for the timeline display in the `AudioLabeling` component.
+    Parameters:
+        height: Timeline height on player, default to 20
+        insertPosition: Timeline relative position
+        primaryLabelInterval: Interval between numeric labels in seconds
+        primaryLabelSpacing: Interval between numeric labels in timeIntervals (i.e notch count)
+        secondaryLabelInterval: Interval between secondary numeric labels in seconds
+        secondaryLabelOpacity: Opacity of the secondary labels, defaults to 0.25
+        secondaryLabelSpacing: Interval between secondary numeric labels in timeIntervals (i.e notch count)
+        timeInterval: Interval between ticks in seconds
+    """
+
+    height: int | float = 20
+    insertPosition: Literal[
+        "afterbegin", "afterend", "beforebegin", "beforeend"
+    ] = "afterend"
+    primaryLabelInterval: int | float = 5
+    primaryLabelSpacing: int | float = 5
+    secondaryLabelInterval: int | float = 1
+    secondaryLabelOpacity: int | float = 0.25
+    secondaryLabelSpacing: int | float = 1
+    timeInterval: int | float = 1
+
+
 @document()
 class AudioLabeling(
     StreamingInput,
@@ -106,6 +133,7 @@ class AudioLabeling(
         min_length: int | None = None,
         max_length: int | None = None,
         waveform_options: WaveformOptions | dict | None = None,
+        timeline_options: TimelineOptions | dict | None = None,
     ):
         """
         Parameters:
@@ -134,6 +162,11 @@ class AudioLabeling(
             min_length: The minimum length of audio (in seconds) that the user can pass into the prediction function. If None, there is no minimum length.
             max_length: The maximum length of audio (in seconds) that the user can pass into the prediction function. If None, there is no maximum length.
             waveform_options: A dictionary of options for the waveform display. Options include: waveform_color (str), waveform_progress_color (str), show_controls (bool), skip_length (int). Default is None, which uses the default values for these options.
+            timeline_options:
+                A dictionary of options for the timeline display.
+                Options include: height, insertPosition, primaryLabelInterval, primaryLabelSpacing,
+                secondaryLabelInterval, secondaryLabelOpacity, secondaryLabelSpacing, timeInterval.
+                See timeline wavesurfer plugin documentation for details about each of these options.
         """
         valid_sources = ["upload", "microphone"]
         if sources is None:
@@ -182,6 +215,14 @@ class AudioLabeling(
             WaveformOptions(**waveform_options)
             if isinstance(waveform_options, dict)
             else waveform_options
+        )
+
+        if timeline_options is None:
+            self.timeline_options = TimelineOptions()
+        self.timeline_options = (
+            TimelineOptions(**timeline_options)
+            if isinstance(timeline_options, dict)
+            else timeline_options
         )
 
         # TODO: What if annotations don't match audio?

--- a/gryannote/audio/frontend/Index.svelte
+++ b/gryannote/audio/frontend/Index.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
 	import type { Gradio, ShareData } from "@gradio/utils";
 	import type { LoadingStatus } from "@gradio/statustracker";
-	import type { WaveformOptions, TimelineOptions} from "./shared/types";
+	import type { WaveformOptions, TimelineOptions, HoverOptions} from "./shared/types";
 	import AnnotatedAudioData from "./shared/AnnotatedAudioData"
 	import StaticAudioLabeling from "./static/StaticAudioLabeling.svelte";
 	import InteractiveAudioLabeling from "./interactive/InteractiveAudioLabeling.svelte";
@@ -32,6 +32,7 @@
 	export let autoplay = false;
 	export let waveform_options: WaveformOptions = {};
 	export let timeline_options: TimelineOptions = {};
+	export let hover_options: HoverOptions = {};
 	export let pending: boolean;
 	export let streaming: boolean;
 	export let gradio: Gradio<{
@@ -140,6 +141,7 @@
 			{waveform_settings}
 			{waveform_options}
 			{timeline_options}
+			{hover_options}
 			on:share={(e) => gradio.dispatch("share", e.detail)}
 			on:error={(e) => gradio.dispatch("error", e.detail)}
 			on:play={() => gradio.dispatch("play")}
@@ -196,6 +198,7 @@
 			{waveform_settings}
 			{waveform_options}
 			{timeline_options}
+			{hover_options}
 		>
 			<UploadText i18n={gradio.i18n} type="audio" />
 		</InteractiveAudioLabeling>

--- a/gryannote/audio/frontend/Index.svelte
+++ b/gryannote/audio/frontend/Index.svelte
@@ -3,7 +3,7 @@
 <script lang="ts">
 	import type { Gradio, ShareData } from "@gradio/utils";
 	import type { LoadingStatus } from "@gradio/statustracker";
-	import type { WaveformOptions} from "./shared/types";
+	import type { WaveformOptions, TimelineOptions} from "./shared/types";
 	import AnnotatedAudioData from "./shared/AnnotatedAudioData"
 	import StaticAudioLabeling from "./static/StaticAudioLabeling.svelte";
 	import InteractiveAudioLabeling from "./interactive/InteractiveAudioLabeling.svelte";
@@ -31,6 +31,7 @@
 	export let loading_status: LoadingStatus;
 	export let autoplay = false;
 	export let waveform_options: WaveformOptions = {};
+	export let timeline_options: TimelineOptions = {};
 	export let pending: boolean;
 	export let streaming: boolean;
 	export let gradio: Gradio<{
@@ -138,6 +139,7 @@
 			{label}
 			{waveform_settings}
 			{waveform_options}
+			{timeline_options}
 			on:share={(e) => gradio.dispatch("share", e.detail)}
 			on:error={(e) => gradio.dispatch("error", e.detail)}
 			on:play={() => gradio.dispatch("play")}
@@ -193,6 +195,7 @@
 			i18n={gradio.i18n}
 			{waveform_settings}
 			{waveform_options}
+			{timeline_options}
 		>
 			<UploadText i18n={gradio.i18n} type="audio" />
 		</InteractiveAudioLabeling>

--- a/gryannote/audio/frontend/interactive/InteractiveAudioLabeling.svelte
+++ b/gryannote/audio/frontend/interactive/InteractiveAudioLabeling.svelte
@@ -14,7 +14,7 @@
 	import AudioRecorder from "../recorder/AudioRecorder.svelte";
 	import StreamAudio from "../streaming/StreamAudio.svelte";
 	import { SelectSource } from "@gradio/atoms";
-	import type { WaveformOptions } from "../shared/types";
+	import type { WaveformOptions, TimelineOptions } from "../shared/types";
 	import Help  from "../shared/icons/Help.svelte"
 	import HelpDialog from "../shared/HelpDialog.svelte";
     import AudioPlayer from "../player/AudioPlayer.svelte";
@@ -35,6 +35,7 @@
 	export let show_minimap: boolean = true;
 	export let waveform_settings: Record<string, any>;
 	export let waveform_options: WaveformOptions = {};
+	export let timeline_options: TimelineOptions = {};
 	export let dragging: boolean;
 	export let active_source: "microphone" | "upload";
 
@@ -278,6 +279,7 @@
 		{show_minimap}
 		{waveform_settings}
 		{waveform_options}
+		{timeline_options}
 		interactive
 		on:stop
 		on:play

--- a/gryannote/audio/frontend/interactive/InteractiveAudioLabeling.svelte
+++ b/gryannote/audio/frontend/interactive/InteractiveAudioLabeling.svelte
@@ -14,7 +14,7 @@
 	import AudioRecorder from "../recorder/AudioRecorder.svelte";
 	import StreamAudio from "../streaming/StreamAudio.svelte";
 	import { SelectSource } from "@gradio/atoms";
-	import type { WaveformOptions, TimelineOptions } from "../shared/types";
+	import type { WaveformOptions, TimelineOptions, HoverOptions } from "../shared/types";
 	import Help  from "../shared/icons/Help.svelte"
 	import HelpDialog from "../shared/HelpDialog.svelte";
     import AudioPlayer from "../player/AudioPlayer.svelte";
@@ -36,6 +36,7 @@
 	export let waveform_settings: Record<string, any>;
 	export let waveform_options: WaveformOptions = {};
 	export let timeline_options: TimelineOptions = {};
+	export let hover_options: HoverOptions = {};
 	export let dragging: boolean;
 	export let active_source: "microphone" | "upload";
 
@@ -280,6 +281,7 @@
 		{waveform_settings}
 		{waveform_options}
 		{timeline_options}
+		{hover_options}
 		interactive
 		on:stop
 		on:play

--- a/gryannote/audio/frontend/player/AudioPlayer.svelte
+++ b/gryannote/audio/frontend/player/AudioPlayer.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
-	import type { Annotation, WaveformOptions , Label} from "../shared/types";
+	import type { WaveformOptions } from "../shared/types";
 	import type { I18nFormatter } from "@gradio/utils";
 	import { Music,} from "@gradio/icons";
 	import WaveSurfer from "@gryannote/wavesurfer.js";
 	import GamepadPlugin from "@gryannote/wavesurfer.js/dist/plugins/gamepad.js";
 	import MiniMapPlugin from "@gryannote/wavesurfer.js/dist/plugins/minimap.js";
+	import TimelinePlugin from '@gryannote/wavesurfer.js/dist/plugins/timeline.js';
+	import HoverPlugin from '@gryannote/wavesurfer.js/dist/plugins/hover.js';
 	import WaveformControls from "../shared/WaveformControls.svelte";
 	import RegionsControl from "./RegionsControl.svelte";
 	import { Empty } from "@gradio/atoms";
@@ -26,14 +28,13 @@
 	let container: HTMLDivElement;
 	let waveform: WaveSurfer | undefined;
 	let wsGamepad: GamepadPlugin;
+	let wsTimeline: TimelinePlugin;
+	let wsHover: HoverPlugin;
 	let wsMinimap: MiniMapPlugin;
 
 	let timeRef: HTMLTimeElement;
 	let durationRef: HTMLTimeElement;
 	let audio_duration: number;
-
-	// correspondence between a Region and an Annotation
-	let regionsMap: Map<string, Annotation> = new Map();
 
 	let caption: Caption;
 
@@ -109,6 +110,24 @@
 	$: waveform?.on("ready", () => {
 		if(!wsGamepad){
 			wsGamepad = waveform.registerPlugin(GamepadPlugin.create());
+		}
+
+		if(!wsTimeline){
+			wsTimeline = waveform.registerPlugin(TimelinePlugin.create({
+				formatTimeCallback: formatTime,
+				timeInterval:0.5,
+				secondaryLabelOpacity:0.5,
+			}));
+		}
+
+		if(!wsHover){
+			wsHover = waveform.registerPlugin(HoverPlugin.create({
+					lineColor: '#ff0000',
+					lineWidth: 2,
+					labelBackground: '#555',
+					labelColor: '#fff',
+					labelSize: '11px',
+			}));
 		}
 
 		if(show_minimap && !wsMinimap){

--- a/gryannote/audio/frontend/player/AudioPlayer.svelte
+++ b/gryannote/audio/frontend/player/AudioPlayer.svelte
@@ -127,6 +127,8 @@
 					labelBackground: '#555',
 					labelColor: '#fff',
 					labelSize: '11px',
+					// just cast seconds to string with 10e-3 precision
+					formatTimeCallback: (seconds: number) => seconds.toFixed(3),
 			}));
 		}
 

--- a/gryannote/audio/frontend/player/AudioPlayer.svelte
+++ b/gryannote/audio/frontend/player/AudioPlayer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { WaveformOptions } from "../shared/types";
+	import type { TimelineOptions, WaveformOptions } from "../shared/types";
 	import type { I18nFormatter } from "@gradio/utils";
 	import { Music,} from "@gradio/icons";
 	import WaveSurfer from "@gryannote/wavesurfer.js";
@@ -22,6 +22,7 @@
 	export let show_minimap: boolean = true;
 	export let waveform_settings: Record<string, any>;
 	export let waveform_options: WaveformOptions;
+	export let timeline_options: TimelineOptions;
 	export let isDialogOpen: boolean;
 	export let mode: string = "";
 
@@ -115,8 +116,7 @@
 		if(!wsTimeline){
 			wsTimeline = waveform.registerPlugin(TimelinePlugin.create({
 				formatTimeCallback: formatTime,
-				timeInterval:0.5,
-				secondaryLabelOpacity:0.5,
+				...timeline_options,
 			}));
 		}
 

--- a/gryannote/audio/frontend/player/AudioPlayer.svelte
+++ b/gryannote/audio/frontend/player/AudioPlayer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import type { TimelineOptions, WaveformOptions } from "../shared/types";
+	import type { HoverOptions, TimelineOptions, WaveformOptions } from "../shared/types";
 	import type { I18nFormatter } from "@gradio/utils";
 	import { Music,} from "@gradio/icons";
 	import WaveSurfer from "@gryannote/wavesurfer.js";
@@ -23,6 +23,7 @@
 	export let waveform_settings: Record<string, any>;
 	export let waveform_options: WaveformOptions;
 	export let timeline_options: TimelineOptions;
+	export let hover_options: HoverOptions;
 	export let isDialogOpen: boolean;
 	export let mode: string = "";
 
@@ -122,13 +123,9 @@
 
 		if(!wsHover){
 			wsHover = waveform.registerPlugin(HoverPlugin.create({
-					lineColor: '#ff0000',
-					lineWidth: 2,
-					labelBackground: '#555',
-					labelColor: '#fff',
-					labelSize: '11px',
-					// just cast seconds to string with 10e-3 precision
-					formatTimeCallback: (seconds: number) => seconds.toFixed(3),
+				// cast seconds to a string with 10e-3 precision
+				formatTimeCallback: (seconds: number) => seconds.toFixed(3),
+				...hover_options,
 			}));
 		}
 

--- a/gryannote/audio/frontend/shared/types.ts
+++ b/gryannote/audio/frontend/shared/types.ts
@@ -8,24 +8,32 @@ export type WaveformOptions = {
 };
 
 export type TimelineOptions = {
-	height?: number
-	nsertPosition?: InsertPosition
-	primaryLabelInterval?: number
-	primaryLabelSpacing?: number,
-	secondaryLabelInterval?: number,
-	secondaryLabelOpacity?: number,
-	secondaryLabelSpacing?: number,
-	timeInterval?: number
+	height?: number;
+	insertPosition?: InsertPosition;
+	primaryLabelInterval?: number;
+	primaryLabelSpacing?: number;
+	secondaryLabelInterval?: number;
+	secondaryLabelOpacity?: number;
+	secondaryLabelSpacing?: number;
+	timeInterval?: number;
+}
+
+export type HoverOptions = {
+	labelBackground?: string;
+	labelColor?: string;
+	labelSize?: string | number;
+	lineColor?: string;
+	lineWidth?: string | number;
 }
 
 export type Annotation = {
-	start: number
-	end: number
-	speaker: string
+	start: number;
+	end: number;
+	speaker: string;
 }
 
 export type Label = {
-	name: string
-	color: string
-	shortcut: string
+	name: string;
+	color: string;
+	shortcut: string;
 }

--- a/gryannote/audio/frontend/shared/types.ts
+++ b/gryannote/audio/frontend/shared/types.ts
@@ -7,6 +7,17 @@ export type WaveformOptions = {
 	show_recording_waveform?: boolean;
 };
 
+export type TimelineOptions = {
+	height?: number
+	nsertPosition?: InsertPosition
+	primaryLabelInterval?: number
+	primaryLabelSpacing?: number,
+	secondaryLabelInterval?: number,
+	secondaryLabelOpacity?: number,
+	secondaryLabelSpacing?: number,
+	timeInterval?: number
+}
+
 export type Annotation = {
 	start: number
 	end: number

--- a/gryannote/audio/frontend/static/StaticAudioLabeling.svelte
+++ b/gryannote/audio/frontend/static/StaticAudioLabeling.svelte
@@ -6,7 +6,7 @@
 	import type { I18nFormatter } from "@gradio/utils";
 	import AudioPlayer from "../player/AudioPlayer.svelte";
 	import { createEventDispatcher } from "svelte";
-	import type { WaveformOptions} from "../shared/types";
+	import type { WaveformOptions, TimelineOptions } from "../shared/types";
 	import AnnotatedAudioData from "../shared/AnnotatedAudioData";
     import { DownloadLink } from "@gradio/wasm/svelte";
 
@@ -17,7 +17,8 @@
 	export let show_minimap: boolean = true;
 	export let i18n: I18nFormatter;
 	export let waveform_settings: Record<string, any>;
-	export let waveform_options: WaveformOptions;
+	export let waveform_options: WaveformOptions = {};
+	export let timeline_options: TimelineOptions = {};
 
 	let show_share_button: boolean = false;
 
@@ -74,6 +75,7 @@
 		{show_minimap}
 		{waveform_settings}
 		{waveform_options}
+		{timeline_options}
 		on:pause
 		on:play
 		on:stop

--- a/gryannote/audio/frontend/static/StaticAudioLabeling.svelte
+++ b/gryannote/audio/frontend/static/StaticAudioLabeling.svelte
@@ -6,7 +6,7 @@
 	import type { I18nFormatter } from "@gradio/utils";
 	import AudioPlayer from "../player/AudioPlayer.svelte";
 	import { createEventDispatcher } from "svelte";
-	import type { WaveformOptions, TimelineOptions } from "../shared/types";
+	import type { WaveformOptions, TimelineOptions, HoverOptions } from "../shared/types";
 	import AnnotatedAudioData from "../shared/AnnotatedAudioData";
     import { DownloadLink } from "@gradio/wasm/svelte";
 
@@ -19,6 +19,7 @@
 	export let waveform_settings: Record<string, any>;
 	export let waveform_options: WaveformOptions = {};
 	export let timeline_options: TimelineOptions = {};
+	export let hover_options: HoverOptions = {};
 
 	let show_share_button: boolean = false;
 
@@ -76,6 +77,7 @@
 		{waveform_settings}
 		{waveform_options}
 		{timeline_options}
+		{hover_options}
 		on:pause
 		on:play
 		on:stop

--- a/gryannote/audio/pyproject.toml
+++ b/gryannote/audio/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "gryannote_audio"
-version = "0.7.2"
+version = "0.8.0"
 description = "audio component with speaker annotations"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
This PR add two new features:
- a timeline on the player, with customizable options in the audio component backend (using timeline plugin from `wavesurfer.js`)
- a timestamp displayed on hovering over waveform with the mouse cursor (using hover plugin from `wavesurfer.js`